### PR TITLE
Auth: add Firebase error mapper, form validation, and loading state in AuthView

### DIFF
--- a/DailyWhiskers/Services/AuthErrorMapper.swift
+++ b/DailyWhiskers/Services/AuthErrorMapper.swift
@@ -1,0 +1,26 @@
+import FirebaseAuth
+import Foundation
+
+enum AuthErrorMapper {
+    static func message(for error: Error) -> String {
+        let nsError = error as NSError
+        guard let code = AuthErrorCode(rawValue: nsError.code) else {
+            return "Something went wrong. Please try again."
+        }
+
+        switch code {
+        case .invalidCredential, .wrongPassword, .userNotFound, .invalidEmail:
+            return "Invalid email or password."
+        case .emailAlreadyInUse:
+            return "An account already exists for that email."
+        case .weakPassword:
+            return "Password is too weak. Use at least 6 characters."
+        case .networkError:
+            return "Network error. Check your connection and try again."
+        case .tooManyRequests:
+            return "Too many attempts. Please wait a moment and try again."
+        default:
+            return "Something went wrong. Please try again."
+        }
+    }
+}

--- a/DailyWhiskers/Views/AuthView.swift
+++ b/DailyWhiskers/Views/AuthView.swift
@@ -86,17 +86,24 @@ struct AuthView: View {
                     Button {
                         Task { await handleEmailSignIn() }
                     } label: {
-                        Text("Sign In")
-                            .font(.system(size: 18, weight: .semibold))
-                            .foregroundStyle(.white)
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 54)
-                            .background(primaryGradient)
-                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                            .shadow(color: Color.orange.opacity(0.22), radius: 10, y: 6)
+                        Group {
+                            if isWorking {
+                                ProgressView()
+                                    .tint(.white)
+                            } else {
+                                Text("Sign In")
+                            }
+                        }
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 54)
+                        .background(primaryGradient)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .shadow(color: Color.orange.opacity(0.22), radius: 10, y: 6)
                     }
                     .padding(.horizontal, 26)
-                    .opacity(canSubmit ? 1 : 0.45)
+                    .opacity(canSubmit || isWorking ? 1 : 0.45)
                     .disabled(!canSubmit)
                     
                     // Secondary: Create Account (outline)
@@ -148,6 +155,12 @@ struct AuthView: View {
                 Spacer()
             }
         }
+        .onChange(of: email) { _, _ in
+            authError = nil
+        }
+        .onChange(of: password) { _, _ in
+            authError = nil
+        }
     }
     
     // MARK: - Subviews
@@ -175,13 +188,22 @@ struct AuthView: View {
     }
 
     private var canSubmit: Bool {
-        !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
-        !password.isEmpty &&
+        isValidEmail(email) &&
+        password.count >= 6 &&
         !isWorking
+    }
+
+    private func isValidEmail(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+
+        let pattern = #"^[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"#
+        return trimmed.range(of: pattern, options: .regularExpression) != nil
     }
 
     private func handleEmailSignIn() async {
         guard !isWorking else { return }
+        guard canSubmit else { return }
         isWorking = true
         authError = nil
         defer { isWorking = false }
@@ -192,12 +214,13 @@ struct AuthView: View {
                 password: password
             )
         } catch {
-            authError = error.localizedDescription
+            authError = AuthErrorMapper.message(for: error)
         }
     }
 
     private func handleEmailCreateAccount() async {
         guard !isWorking else { return }
+        guard canSubmit else { return }
         isWorking = true
         authError = nil
         defer { isWorking = false }
@@ -208,7 +231,7 @@ struct AuthView: View {
                 password: password
             )
         } catch {
-            authError = error.localizedDescription
+            authError = AuthErrorMapper.message(for: error)
         }
     }
 
@@ -224,7 +247,7 @@ struct AuthView: View {
                 password: TestAccount.password
             )
         } catch {
-            authError = error.localizedDescription
+            authError = AuthErrorMapper.message(for: error)
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Provide clearer, user-friendly error messages for Firebase auth failures instead of raw `Error` descriptions.
- Prevent submission of malformed credentials and communicate in-progress sign-in state in the UI.
- Reset displayed auth errors when the user edits inputs to avoid stale error text.

### Description
- Added `AuthErrorMapper.swift` which maps `FirebaseAuth` `AuthErrorCode` values to localized user-friendly strings.
- Updated `AuthView` to show a `ProgressView` in the primary Sign In button while `isWorking` is true and to keep button opacity active during loading.
- Strengthened client-side validation by replacing trimmed-empty checks with `isValidEmail(_:)` (regex) and a minimum password length, and used `canSubmit` guards in `handleEmailSignIn` and `handleEmailCreateAccount`.
- Cleared `authError` on changes to `email` and `password`, and switched error handling to use `AuthErrorMapper.message(for:)` for all email-based auth flows.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ca7353488332870c2421ec8a40da)