### PR TITLE
Pass 1 Item 3: Day rollover behavior on foreground

### DIFF
--- a/DailyWhiskers/Services/DailyContentProvider.swift
+++ b/DailyWhiskers/Services/DailyContentProvider.swift
@@ -25,13 +25,21 @@ struct DailyContentProvider {
     }
 
     func contentForToday() -> DailyCard? {
+        content(for: Date())
+    }
+
+    func content(for date: Date) -> DailyCard? {
         guard !manifest.cards.isEmpty else {
             Self.logger.error("Manifest unexpectedly empty after load; using fallback card.")
             return Self.fallbackCard
         }
 
-        let seed = daySeed(for: Date())
+        let seed = daySeed(for: date)
         return manifest.cards[seed % manifest.cards.count]
+    }
+
+    func dayIdentifier(for date: Date) -> Int {
+        daySeed(for: date)
     }
 
     private func daySeed(for date: Date) -> Int {

--- a/DailyWhiskers/Views/DailyWhiskersView.swift
+++ b/DailyWhiskers/Views/DailyWhiskersView.swift
@@ -2,13 +2,17 @@ import SwiftUI
 
 struct DailyWhiskersView: View {
     @EnvironmentObject private var router: AppRouter
+    @Environment(\.scenePhase) private var scenePhase
 
     private let provider = DailyContentProvider()
+
+    @State private var currentCard: DailyCard?
+    @State private var currentDayIdentifier: Int?
 
     var body: some View {
         NavigationStack {
             ZStack {
-                if let entry = provider.contentForToday() {
+                if let entry = currentCard {
                     DailyRitualCardView(
                         data: DailyCardData(
                             archetype: entry.archetype,
@@ -24,6 +28,13 @@ struct DailyWhiskersView: View {
                             .foregroundStyle(.secondary)
                     }
                 }
+            }
+            .onAppear {
+                refreshDailyContentIfNeeded(force: true)
+            }
+            .onChange(of: scenePhase) { _, newPhase in
+                guard newPhase == .active else { return }
+                refreshDailyContentIfNeeded(force: false)
             }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -43,6 +54,17 @@ struct DailyWhiskersView: View {
             .navigationTitle("")
             .navigationBarTitleDisplayMode(.inline)
         }
+    }
+
+    private func refreshDailyContentIfNeeded(force: Bool) {
+        let todayIdentifier = provider.dayIdentifier(for: Date())
+
+        guard force || currentDayIdentifier != todayIdentifier else {
+            return
+        }
+
+        currentCard = provider.content(for: Date())
+        currentDayIdentifier = todayIdentifier
     }
 }
 


### PR DESCRIPTION
Implements daily content refresh when app returns to foreground and local day changed; adds date-based provider helpers and view state tracking.